### PR TITLE
Remove redundant logic for theme-color meta tag handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lonadels.ru",
-  "version": "1.18.1",
+  "version": "1.18.2",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -59,12 +59,6 @@ export const metadata: Metadata = {
   },
 };
 
-export const viewport: Viewport = {
-  themeColor: [
-    { media: '(prefers-color-scheme: light)', color: '#ffffff' },
-    { media: '(prefers-color-scheme: dark)', color: '#0a0a0a' },
-  ],
-};
 
 export default async function RootLayout({
                                            children,

--- a/src/components/theme-color-meta.tsx
+++ b/src/components/theme-color-meta.tsx
@@ -14,11 +14,6 @@ export function ThemeColorMeta() {
       const head = document.head
       if (!head || !head.isConnected) return
 
-      head.querySelectorAll<HTMLMetaElement>('meta[name="theme-color"]').forEach((el) => {
-        if (el.id !== id && el.parentNode && (el as HTMLMetaElement).isConnected && 'removeChild' in el.parentNode) {
-          el.parentNode?.removeChild(el)
-        }
-      })
 
       const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches
       const currentTheme = resolvedTheme ?? (prefersDark ? 'dark' : 'light')


### PR DESCRIPTION
The unnecessary logic for removing theme-color meta tags and associated viewport definitions from the layout has been eliminated. This simplifies the implementation and ensures a leaner setup.